### PR TITLE
Update to latest FFSVM 0.12, making visqol compile on stable.

### DIFF
--- a/visqol-rs/Cargo.toml
+++ b/visqol-rs/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.10.3"
 num-traits = "0.2.15"
 rustfft = "6.0.1"
 serde = { version = "1.0", features = ["derive"] }
-ffsvm = "0.9.1"
+ffsvm = "0.12.0"
 thiserror = "1.0.32"
 log = "0.4.17"
 

--- a/visqol-rs/src/support_vector_regression_model.rs
+++ b/visqol-rs/src/support_vector_regression_model.rs
@@ -1,4 +1,4 @@
-use ffsvm::{self, DenseProblem, DenseSVM, Predict, Solution};
+use ffsvm::{self, DenseFeatures, DenseSVM, Predict, Label};
 use std::convert::TryFrom;
 use std::fs::read_to_string;
 
@@ -19,7 +19,7 @@ impl SupportVectorRegressionModel {
     }
     /// Given a slice of features, this function produces a single score.
     pub fn predict(&self, observation: &[f64]) -> f64 {
-        let mut problem = DenseProblem::from(&self.model);
+        let mut problem = DenseFeatures::from(&self.model);
         let features = problem.features();
 
         for (i, element) in observation.iter().enumerate() {
@@ -28,9 +28,9 @@ impl SupportVectorRegressionModel {
         self.model
             .predict_value(&mut problem)
             .expect("Failed to compute prediction");
-        let solution = problem.solution();
+        let solution = problem.label();
         let mut score = 0.0;
-        if let Solution::Value(s) = solution {
+        if let Label::Value(s) = solution {
             score = s;
         }
         score as f64


### PR DESCRIPTION
Thanks for using FFSVM, author here.

Up until just now FFSVM required Rust nightly. With the new 0.12 it compiles on stable. This PR updates the dependency inside visqol. With this you should compile on stable Rust 1.83+ (I've tested this on my machine). I can also report it works on Windows, at least according to `cargo test`.