### PR TITLE
Embed default SVM model for improved portability

### DIFF
--- a/visqol-rs/src/lib.rs
+++ b/visqol-rs/src/lib.rs
@@ -51,7 +51,7 @@ mod similarity_to_quality_mapper;
 mod spectrogram;
 mod spectrogram_builder;
 mod speech_similarity_to_quality_mapper;
-mod support_vector_regression_model;
+pub mod support_vector_regression_model;  /// make public
 mod svr_similarity_to_quality_mapper;
 mod vad_patch_creator;
 pub mod variant;

--- a/visqol-rs/src/support_vector_regression_model.rs
+++ b/visqol-rs/src/support_vector_regression_model.rs
@@ -1,6 +1,9 @@
 use ffsvm::{self, DenseFeatures, DenseSVM, Label, Predict};
 use std::convert::TryFrom;
-use std::fs::read_to_string;
+
+/// The default content of the model, embedded in the binary at compile time.
+/// The path is specified relative to the current file.
+const DEFAULT_MODEL_CONTENT: &str = include_str!("../../model/libsvm_nu_svr_model.txt");
 
 /// Thin wrapper around `ffsvm` to compute a prediction from a support vector machine.
 pub struct SupportVectorRegressionModel {
@@ -8,15 +11,20 @@ pub struct SupportVectorRegressionModel {
 }
 
 impl SupportVectorRegressionModel {
-    /// Given a path to a `LibSVM` formatted `.txt` file, the model is initialized with its corresponding weights.
-    pub fn new(model_path: &str) -> Self {
-        let model_description = read_to_string(model_path)
-            .unwrap_or_else(|_| panic!("failed to read model path from {}!", model_path));
+    /// Creates a model from a string containing a description in LibSVM format.
+    /// That is the main constructor, which is independent of the file system.
+    pub fn from_str(model_description: &str) -> Self {
         Self {
-            model: DenseSVM::try_from(model_description.as_str())
-                .expect("Failed to load SVM model"),
+            model: DenseSVM::try_from(model_description)
+                .expect("Failed to load SVM model from string"),
         }
     }
+
+    /// Creates an instance of the model with standard, built-in weights.
+    pub fn default() -> Self {
+        Self::from_str(DEFAULT_MODEL_CONTENT)
+    }
+
     /// Given a slice of features, this function produces a single score.
     pub fn predict(&self, observation: &[f64]) -> f64 {
         let mut problem = DenseFeatures::from(&self.model);
@@ -43,14 +51,8 @@ mod tests {
     use approx::assert_abs_diff_eq;
     #[test]
     fn svn_predicts_known_mos() {
-        let model_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/",
-            "..",
-            "/",
-            "model/libsvm_nu_svr_model.txt"
-        );
-        let svm = SupportVectorRegressionModel::new(model_path);
+        // The test now uses the built-in model, and no longer needs to calculate the relative path.
+        let svm = SupportVectorRegressionModel::default();
 
         // This is the FVNSIM results for a ViSQOL comparison between
         // contrabassoon48_stereo.wav and contrabassoon48_stereo_24kbps_aac.wav

--- a/visqol-rs/src/svr_similarity_to_quality_mapper.rs
+++ b/visqol-rs/src/svr_similarity_to_quality_mapper.rs
@@ -7,11 +7,9 @@ pub struct SvrSimilarityToQualityMapper {
 }
 
 impl SvrSimilarityToQualityMapper {
-    /// Initializes the model's weights with a libSVM formatted file located in `model_path`
-    pub fn new(model_path: &str) -> Self {
-        Self {
-            model: SupportVectorRegressionModel::new(model_path),
-        }
+    /// Initializes the model's weights with a libSVM as embedded SupportVectorRegressionModel instead of the file path
+    pub fn new(model: SupportVectorRegressionModel) -> Self {
+        Self { model }
     }
 }
 

--- a/visqol-rs/src/variant.rs
+++ b/visqol-rs/src/variant.rs
@@ -1,4 +1,6 @@
+use crate::support_vector_regression_model::SupportVectorRegressionModel;
+
 pub enum Variant {
-    Fullband { model_path: String },
+    Fullband { model: SupportVectorRegressionModel },  /// use SupportVectorRegressionModel instead of the file path
     Wideband { use_unscaled_mos_mapping: bool },
 }

--- a/visqol-rs/src/visqol_manager.rs
+++ b/visqol-rs/src/visqol_manager.rs
@@ -41,9 +41,11 @@ impl<const NUM_BANDS: usize> VisqolManager<NUM_BANDS> {
                     !use_unscaled_mos_mapping,
                 ));
             }
-            Variant::Fullband { model_path } => {
+            /// Destructure the `variant` to get the 'model` field, instead of the file path `model_path'.
+            Variant::Fullband { model } => {
                 patch_creator = Box::new(ImagePatchCreator::new(PATCH_SIZE_SPEECH));
-                sim_to_quality_mapper = Box::new(SvrSimilarityToQualityMapper::new(&model_path));
+                /// Pass the ready-made `model` object to the constructor `SvrSimilarityToQualityMapper::new`.
+                sim_to_quality_mapper = Box::new(SvrSimilarityToQualityMapper::new(model));
             }
         }
 

--- a/visqol/Cargo.toml
+++ b/visqol/Cargo.toml
@@ -19,7 +19,7 @@ example = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-visqol-rs = "0.3.1"
+visqol-rs = { path = "../visqol-rs" } # use local
 clap = { version = "4.5.7", features = ["derive"] }
 log = "0.4.17"
 simplelog = "0.12.0"

--- a/visqol/src/command_line_utils.rs
+++ b/visqol/src/command_line_utils.rs
@@ -21,12 +21,9 @@ pub enum Subcommands {
     Fullband {
         /// The libsvm model to use during comparison. Use this only if you
         /// want to explicitly specify the model file location, otherwise the
-        /// default model will be used.
-        #[clap(
-            long = "similarity_to_quality_model",
-            default_value = "./model/libsvm_nu_svr_model.txt"
-        )]
-        similarity_to_quality_model: String,
+        /// default (embedded) model will be used.
+        #[clap(long = "similarity_to_quality_model")]
+        similarity_to_quality_model: Option<String>, /// use Option<String> instead of the file path
     },
 }
 

--- a/visqol/src/main.rs
+++ b/visqol/src/main.rs
@@ -2,10 +2,12 @@ use clap::Parser;
 use log::LevelFilter;
 use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
 use std::error::Error;
+use std::fs;
 
 use visqol_rs::{
     constants::{NUM_BANDS_AUDIO, NUM_BANDS_SPEECH},
     similarity_result::SimilarityResult,
+    support_vector_regression_model::SupportVectorRegressionModel,
     variant::Variant,
     visqol_manager::VisqolManager,
 };
@@ -59,9 +61,25 @@ fn main() -> Result<(), Box<dyn Error>> {
         command_line_utils::Subcommands::Fullband {
             similarity_to_quality_model,
         } => {
-            variant = Variant::Fullband {
-                model_path: similarity_to_quality_model.clone(),
+            /// Creating an SVM model depending on whether the user has specified the path.
+            let svm_model = match similarity_to_quality_model {
+                /// If the path is specified, read the file and create a model from its contents.
+                Some(path) => {
+                    log::info!("Loading custom SVM model from: {}", path);
+                    let model_content = fs::read_to_string(path)?;
+                    SupportVectorRegressionModel::from_str(&model_content)
+                }
+                // If the path is not specified, we use the built-in default model.
+                None => {
+                    log::info!("Using embedded default SVM model.");
+                    SupportVectorRegressionModel::default()
+                }
             };
+
+            // Creating a variant with a ready-made model
+            variant = Variant::Fullband { model: svm_model };
+
+            // VisqolManager::new should now accept this new variant.
             visqol_audio = VisqolManager::new(variant, args.search_window_radius);
             results = run(&files_to_compare, &mut visqol_audio)?;
         }


### PR DESCRIPTION
First off, thanks for creating this useful tool.

This PR embeds the default SVM model directly into the binary at compile time, resolving these issues:

1.  working directory dependency: the application requires execution from the project root to find the default model (`./model/libsvm_nu_svr_model.txt`), running the binary from other locations causes errors.
2.  distribution: standard use requires users to keep the executable and the `model` folder together, but the ~100KB model file is ideal for embedding.

Changes:

-   **embedded model:** `support_vector_regression_model.rs` now uses `include_str!` to embed `libsvm_nu_svr_model.txt` into a `const` string. `SupportVectorRegressionModel::default()` uses this embedded data.
-   **optional CLI Flag:** `--similarity_to_quality_model` flag (`command_line_utils.rs`) is now an `Option<String>` without a default value.
    -   If not provided, the application uses the embedded model.
    -   If provided, it loads a custom model from the specified path, preserving existing functionality.
-   **internal logic updates:** `Variant::Fullband` now carries a `SupportVectorRegressionModel` object instead of a `String` path. `VisqolManager` and `SvrSimilarityToQualityMapper` accept the pre-constructed model object, improving separation of concerns.

Benefits:

*   **full portability:** the binary is now self-contained and runs from any directory.
*   **better UX:** no separate `model` folder is needed for standard analysis: users can just "build/download and run."
*   **maintained flexibility:** custom model file usage remains supported.
